### PR TITLE
Adaptando overflow de cartas para mobile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@types/node": "^16.18.91",
         "@types/react": "^18.2.73",
         "@types/react-dom": "^18.2.22",
+        "classnames": "^2.5.1",
         "react": "^18.2.0",
         "react-currency-input-field": "^3.8.0",
         "react-dom": "^18.2.0",
@@ -5894,6 +5895,11 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
       "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ=="
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
     },
     "node_modules/clean-css": {
       "version": "5.3.3",
@@ -22581,6 +22587,11 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
       "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ=="
+    },
+    "classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
     },
     "clean-css": {
       "version": "5.3.3",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@types/node": "^16.18.91",
     "@types/react": "^18.2.73",
     "@types/react-dom": "^18.2.22",
+    "classnames": "^2.5.1",
     "react": "^18.2.0",
     "react-currency-input-field": "^3.8.0",
     "react-dom": "^18.2.0",

--- a/src/App/Components/Card/Card.module.scss
+++ b/src/App/Components/Card/Card.module.scss
@@ -14,6 +14,10 @@
     border-radius: 0.5rem;
     margin: 15px;
 
+    &.cardMargin {
+        margin-left: -14vw;
+    }
+
     @include respond(phone) {
         height: 150px;
         width: 90px;

--- a/src/App/Components/Card/Card.tsx
+++ b/src/App/Components/Card/Card.tsx
@@ -1,19 +1,25 @@
 import styles from  "./Card.module.scss"
 import Suit from "../Suit";
-import React from "react";
+import React, {useContext} from "react";
+import cx from "classnames";
+import {AppContext} from "../../context/AppContext";
 
 export interface cardProps {
     suit: string
     number: string
     color: string
     isDown?: boolean
+    handSize?: number
 }
 
-const Card = ({suit, number, color, isDown=false} : cardProps) => {
+const Card = ({suit, number, color, isDown=false, handSize} : cardProps) => {
+    const { isMobile } = useContext(AppContext)
+    const cardMarginStyle = (handSize && handSize >= 3 && isMobile) ? styles.cardMargin : ''
+
     return (
        <>
            {isDown &&
-               <div className={styles.card}>
+               <div className={cx(styles.card, cardMarginStyle)}>
                     <div className={styles.cardDown}>
                         <div className={styles.cardDown}>
                         </div>
@@ -22,7 +28,7 @@ const Card = ({suit, number, color, isDown=false} : cardProps) => {
            }
 
            {!isDown &&
-               <div className={styles.card}>
+               <div className={cx(styles.card, cardMarginStyle)}>
                    <div className={styles.numberTop}>
                        <div style={{color: color}}>{number}</div>
                    </div>

--- a/src/App/Components/GameStarted/GameActionsContainer.module.scss
+++ b/src/App/Components/GameStarted/GameActionsContainer.module.scss
@@ -27,6 +27,10 @@
 
 .handDeck {
   display: flex;
+
+  &.cardsOverflow {
+    margin-left: 18vw;
+  }
 }
 
 .resultText {

--- a/src/App/Components/GameStarted/GameActionsContainer.tsx
+++ b/src/App/Components/GameStarted/GameActionsContainer.tsx
@@ -7,6 +7,7 @@ import {cardProps} from "../Card/Card";
 import IconTooltip from "../IconTooltip";
 import {AppContext} from "../../context/AppContext";
 import React  from 'react';
+import cx from "classnames";
 
 type PercentageDealerHitMap = {
     [sum: number]: number;
@@ -217,7 +218,7 @@ const GameActionsContainer = ({setIsGameStarted, setValueOwn, betValue} : GameAc
                 <h1 className={styles.title}>Mão do Dealer ({sumDealerHand})</h1>
             </div>
 
-            <div className={styles.handDeck}>
+            <div className={cx(styles.handDeck, { [styles.cardsOverflow]: (dealerHand.length >= 3 && isMobile) })}>
                 {dealerHand.map((cardData) => (
                     <Card
                         key={cardData.suit + cardData.number}
@@ -225,6 +226,7 @@ const GameActionsContainer = ({setIsGameStarted, setValueOwn, betValue} : GameAc
                         number={cardData.number}
                         color={cardData.color}
                         isDown={cardData.isDown}
+                        handSize={dealerHand.length}
                     />
                 ))}
             </div>
@@ -233,13 +235,14 @@ const GameActionsContainer = ({setIsGameStarted, setValueOwn, betValue} : GameAc
                 <h1 className={styles.title}>Sua mão ({sumPlayerHand})</h1>
             </div>
 
-            <div className={styles.handDeck}>
+            <div className={cx(styles.handDeck, { [styles.cardsOverflow]: (playerHand.length >= 3 && isMobile) })}>
                 {playerHand.map((cardData, index) => (
                     <Card
                         key={index}
                         suit={cardData.suit}
                         number={cardData.number}
                         color={cardData.color}
+                        handSize={playerHand.length}
                     />
                 ))}
             </div>


### PR DESCRIPTION
Este PR ajusta o overflow das cartas em mobile, quando elas atingem uma quantidade de 3 ou mais na mão. Além disso, adicionei o pacote `classnames`, que permite concatenar as classes css.

![image](https://github.com/luismenslin/blackjack/assets/130087613/276257bf-6a1f-470e-b463-98183d244282)